### PR TITLE
updated local-run.sh and Dockerfile to use the new --bbs arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ FROM openjdk
 EXPOSE 6510
 WORKDIR /bbs
 COPY --from=build /bbs/target/* /bbs/
-ENTRYPOINT ["java", "-jar","petscii-bbs.jar","-b","CsdbReleases"]
+ENTRYPOINT ["java", "-jar","petscii-bbs.jar","--bbs","StdChoice:23"]

--- a/local-run.sh
+++ b/local-run.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
-rm -rf target/ && mvn package && java -jar target/petscii-bbs-1.0-SNAPSHOT.jar -b MainMenu
+#!/usr/bin/bash
+rm -rf target/ && mvn package && java -jar target/petscii-bbs.jar --bbs StdChoice:23


### PR DESCRIPTION
I believe the dockerfile and local run script are using the old -b arg instead of the new --bbs arg.

I changed the default BBS to StdChoice because I was confused as to which one took me to what I see on retrocampus